### PR TITLE
InferenceService tolerations look for a generic Nvidia GPU taint

### DIFF
--- a/kubernetes/llama-serve/granite3.2-8b/inferenceservice.yaml
+++ b/kubernetes/llama-serve/granite3.2-8b/inferenceservice.yaml
@@ -34,4 +34,6 @@ spec:
     tolerations:
       - effect: NoSchedule
         key: nvidia.com/gpu
-        value: NVIDIA-A10G-SHARED
+        value: "True"
+        operator: Equal
+

--- a/kubernetes/llama-serve/llama3.2-1b/inferenceservice.yaml
+++ b/kubernetes/llama-serve/llama3.2-1b/inferenceservice.yaml
@@ -34,4 +34,5 @@ spec:
     tolerations:
       - effect: NoSchedule
         key: nvidia.com/gpu
-        value: NVIDIA-A10G-SHARED
+        value: "True"
+        operator: Equal

--- a/kubernetes/llama-serve/llama3.2-3b/inferenceservice.yaml
+++ b/kubernetes/llama-serve/llama3.2-3b/inferenceservice.yaml
@@ -34,7 +34,5 @@ spec:
     tolerations:
       - effect: NoSchedule
         key: nvidia.com/gpu
-        value: NVIDIA-L40-SHARED
-      - effect: NoSchedule
-        key: nvidia.com/gpu
-        value: NVIDIA-L40S-SHARED
+        value: "True"
+        operator: Equal


### PR DESCRIPTION
This change removes specific models that could negatively impact on scheduling causing the Granite and Llama inference services to get stuck in Pending state even if nodes with Nvidia GPU are available.